### PR TITLE
jekyll: fix deprecation warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,4 +13,4 @@ permalink: pretty
 paginate: 5
 exclude: ["less","node_modules","Gruntfile.js","package.json","README.md"]
 
-gems: [jekyll-paginate, jekyll-feed]
+plugins: [jekyll-paginate, jekyll-feed]


### PR DESCRIPTION
The 'gems' configuration option has been renamed to 'plugins'.

See https://jekyllrb.com/news/2017/06/15/jekyll-3-5-0-released/

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>