### PR TITLE
Replace deprecated URI, in `2019-03-11-flatpak-problems.markdown`, with its replacement.

### DIFF
--- a/_posts/2019-03-11-flatpak-problems.markdown
+++ b/_posts/2019-03-11-flatpak-problems.markdown
@@ -41,7 +41,7 @@ the actual handler
 
 It’s not even close to being elegant, and people are already arguing about removing
 support (or, rather, coming up with a better alternative) for such things:
-<https://bugs.python.org/issue33944>. To support such an implementation, we would
+<https://github.com/python/cpython/issues/78125#issue-1198993802>. To support such an implementation, we would
 likely need to provide a runtime extension, or ask anyone shipping Python to include
 our handler.
 


### PR DESCRIPTION
I replaced [`bugs.python.org/issue33944`](https://bugs.python.org/issue33944) with [`python/cpython/issues/78125`](https://github.com/python/cpython/issues/78125#issue-1198993802). This remains pertinent, whilst [`flatpak/flatpak/issues/1222`](https://github.com/flatpak/flatpak/issues/1222#issue-278455583) remains open.